### PR TITLE
Fix to output a session value in the format of Rails 4.1 or later

### DIFF
--- a/lib/rails_4_session_flash_backport/rails3-1/flash_hash.rb
+++ b/lib/rails_4_session_flash_backport/rails3-1/flash_hash.rb
@@ -37,15 +37,14 @@ module ActionDispatch
       end
 
       def to_session_value
-        flashes_to_keep = @flashes.except(*@used)
-        return nil if flashes_to_keep.empty?
-        {'flashes' => flashes_to_keep}
+        return nil if @flashes.empty?
+        {'discard' => @used.to_a, 'flashes' => @flashes}
       end
 
       def initialize(flashes = {}, discard = []) #:nodoc:
         @used    = Set.new(discard)
         @closed  = false
-        @flashes = flashes
+        @flashes = flashes.stringify_keys
         @now     = nil
       end
 

--- a/spec/rails3-1/flash_hash_spec.rb
+++ b/spec/rails3-1/flash_hash_spec.rb
@@ -66,7 +66,7 @@ describe ActionDispatch::Flash::FlashHash, "backport" do
     end
 
     it "dumps to basic objects like rails 4" do
-      expect(flash.to_session_value).to eq("flashes" => {"greeting" => "Hello"})
+      expect(flash.to_session_value).to eq("discard" => ["farewell"], "flashes" => {"greeting" => "Hello", "farewell" => "Goodbye"})
     end
   end
 end


### PR DESCRIPTION
Rails 4 expects that 'flashes' keys are String.
And, 'discard' is required.
See: https://github.com/rails/rails/commit/a668beffd64106a1e1fedb71cc25eaaa11baf0c1
