### PR TITLE
Fix ActionDispatch::Flash::FlashHash#to_session_value on Rails 3.x

### DIFF
--- a/lib/rails_4_session_flash_backport/rails3-1/flash_hash.rb
+++ b/lib/rails_4_session_flash_backport/rails3-1/flash_hash.rb
@@ -38,13 +38,13 @@ module ActionDispatch
 
       def to_session_value
         return nil if @flashes.empty?
-        {'discard' => @used.to_a, 'flashes' => @flashes}
+        self
       end
 
       def initialize(flashes = {}, discard = []) #:nodoc:
         @used    = Set.new(discard)
         @closed  = false
-        @flashes = flashes.stringify_keys
+        @flashes = flashes
         @now     = nil
       end
 

--- a/spec/rails3-1/flash_hash_spec.rb
+++ b/spec/rails3-1/flash_hash_spec.rb
@@ -61,12 +61,15 @@ describe ActionDispatch::Flash::FlashHash, "backport" do
     subject(:flash) { described_class.new }
 
     before do
-      flash["greeting"] = "Hello"
-      flash.now["farewell"] = "Goodbye"
+      flash[:greeting] = "Hello"
+      flash.now[:farewell] = "Goodbye"
     end
 
-    it "dumps to basic objects like rails 4" do
-      expect(flash.to_session_value).to eq("discard" => ["farewell"], "flashes" => {"greeting" => "Hello", "farewell" => "Goodbye"})
+    it "dumps to basic objects like rails 3.x" do
+      session_value = flash.to_session_value
+      expect(session_value.is_a? ActionDispatch::Flash::FlashHash).to be_truthy
+      expect(session_value.instance_variable_get(:@used)).to eq([:farewell].to_set)
+      expect(session_value.instance_variable_get(:@flashes)).to eq({:greeting => "Hello", :farewell => "Goodbye"})
     end
   end
 end


### PR DESCRIPTION
Rails 4.2ではフラッシュをハッシュ形式でセッションに格納します。

``` ruby
{"discard"=>[], "flashes"=>{"sample"=>"This is sample message."}}
```

一方、Rails 3.2ではフラッシュを `ActionDispatch::Flash::FlashHash` のオブジェクトとしてセッションに格納します。

``` ruby
#<ActionDispatch::Flash::FlashHash:0x0055b297ab94c0 @flashes={:sample=>"This is sample message."}, @now=nil, @used=#<Set: {}>, @closed=false>
```

このGemはRails 3.x側に入れて利用し、Rails 3.xでRails 4.xのフラッシュを扱えるようにするためのものです。
また、Rails 3.xでRails 4.xのフラッシュが読めるようになるだけでなく、Rails 3.xでフラッシュをハッシュ形式で出力するようにもなっていました。

ただし、このGemがRails 3.2で出力するハッシュ形式のフラッシュは不完全で、Rails 4.2は解釈できませんでした。
具体的にはハッシュのキーが文字列ではなく、シンボルになっていました。

``` ruby
{"discard"=>[], "flashes"=>{:sample=>"This is sample message."}}
```

そこで、 #1 でキーを文字列にしたところ、Rails 3内で問題が発生しました。

[Rails 4.2ではRails 3.2の形式も解釈できる](https://github.com/rails/rails/commit/a668beffd64106a1e1fedb71cc25eaaa11baf0c1#diff-61a98c1c4d1d7dfb1536acde173082f3R81)ことを利用し、
Rails 3.2からはハッシュではなく本来の形式である `ActionDispatch::Flash::FlashHash` でセッションに格納するように修正しました。
